### PR TITLE
Update indelCaller.py

### DIFF
--- a/nanocaller_src/indelCaller.py
+++ b/nanocaller_src/indelCaller.py
@@ -286,10 +286,13 @@ def call_manager(params):
     
     if params['mode']=='snps' or params['mode']=='all':
         output_files['snps']=os.path.join(params['vcf_path'],'%s.snps.phased.vcf.gz' %params['prefix'])
-
-        phased_snps_files=' '.join(phased_snp_files_list)
         
-        run_cmd('bcftools concat %s --threads %d|bgziptabix %s' %(phased_snps_files, params['cpu'], output_files['snps']))
+        # Make a file out of this list
+        with open('tmp_psfl', 'w') as fo:
+            for psfl in phased_snp_files_list:
+                fo.write(psfl + '\n')       
+        # Read from file instead of from shell
+        run_cmd('bcftools concat -f tmp_psfl --threads %d|bgziptabix %s' %(params['cpu'], output_files['snps']))
         
     if params['mode']=='indels' or params['mode']=='all':
         raw_indel_vcf=os.path.join(params['intermediate_indel_files_dir'],'%s.raw.indel.vcf' %params['prefix'])


### PR DESCRIPTION
When there are multiple indel files this command line:

run_cmd('bcftools concat %s --threads %d|bgziptabix %s' %(phased_snps_files, params['cpu'], output_files['snps']))

is too long and produces an error that can't be solved by increasing **ARG_MAX** limit.

To avoid producing such long command line, the file names are stored in a file and instead of calling these names in the bcftools, the -f option is used with the file name, so the line size is reduced and the error is avoided.