### PR TITLE
Update environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - pysam
   - python>=3.8
   - samtools>=1.10
-  - tensorflow>=2.2
+  - tensorflow==2.15.0
   - whatshap>=2.0
   - vcflib
   - intervaltree=3.*


### PR DESCRIPTION
This fixes issue #47
With current requirement, it will install tensorflow 2.17.0 and NanoCaller will fail. Following the proposal found in issue #47, I fix the dependency version to 2.15.0 and it works.